### PR TITLE
Remove duplicate standardizing code and import from utilities

### DIFF
--- a/scripts/build_hs_mapping.py
+++ b/scripts/build_hs_mapping.py
@@ -5,142 +5,13 @@ This script creates the canonical mapping for high school names
 """
 
 import pandas as pd
-import re
 from pathlib import Path
-from collections import defaultdict
+from hs_standardization import (
+    create_duplicate_mapping,
+    create_prep_school_mapping
+)
 
 DATA_DIR = Path("data")
-
-def select_canonical_name(group_df):
-    """
-    Given a group of duplicate high school names, select the canonical one.
-
-    Strategy (in order of preference):
-    1. Most common version (highest player_count)
-    2. If tie, prefer "High School" over "HS" or "H.S."
-    3. If still tie, prefer version without periods
-    4. If still tie, take first alphabetically
-    """
-
-    # Start with most common
-    group_df = group_df.sort_values('player_count', ascending=False)
-
-    max_count = group_df.iloc[0]['player_count']
-    top_candidates = group_df[group_df['player_count'] == max_count].copy()
-
-    if len(top_candidates) == 1:
-        return top_candidates.iloc[0]
-
-    # Prefer "High School" suffix
-    def score_name(name):
-        score = 0
-        if 'High School' in str(name):
-            score += 100
-        elif ' HS' in str(name) and 'H.S.' not in str(name):
-            score += 50
-        # Deduct points for periods
-        score -= str(name).count('.') * 10
-        return score
-
-    top_candidates['name_score'] = top_candidates['high_school_original'].apply(score_name)
-    top_candidates = top_candidates.sort_values(['name_score', 'high_school_original'],
-                                                  ascending=[False, True])
-
-    return top_candidates.iloc[0]
-
-
-def create_duplicate_mapping(duplicates_file):
-    """
-    Create mapping from duplicate variations to canonical names.
-    """
-    print("Creating duplicate mapping...")
-
-    df = pd.read_csv(duplicates_file)
-
-    # Group by normalized name and state
-    mappings = []
-
-    for (normalized, state), group in df.groupby(['high_school_normalized', 'state']):
-        if len(group) == 1:
-            continue
-
-        # Select canonical name
-        canonical = select_canonical_name(group)
-
-        # Create mappings for all variations
-        for _, row in group.iterrows():
-            mappings.append({
-                'high_school_original': row['high_school_original'],
-                'high_school_standardized': canonical['high_school_original'],
-                'state': state,
-                'confidence': 'high_auto',
-                'source': 'duplicate_resolution',
-                'nces_id': None,
-                'player_count': row['player_count'],
-                'canonical_player_count': canonical['player_count']
-            })
-
-    mapping_df = pd.DataFrame(mappings)
-
-    print(f"Created {len(mapping_df)} mappings from duplicate resolution")
-    print(f"Reduced to {mapping_df['high_school_standardized'].nunique()} canonical names")
-
-    return mapping_df
-
-
-def create_prep_school_mapping():
-    """
-    Create manual curated mapping for well-known prep schools and basketball academies.
-    These schools won't be in NCES public school database.
-    """
-    print("\nCreating prep school manual mapping...")
-
-    # Well-known basketball prep schools and academies
-    prep_schools = [
-        {'original': 'IMG Academy', 'standardized': 'IMG Academy', 'city': 'Bradenton', 'state': 'FL'},
-        {'original': 'Montverde Academy', 'standardized': 'Montverde Academy', 'city': 'Montverde', 'state': 'FL'},
-        {'original': 'Oak Hill Academy', 'standardized': 'Oak Hill Academy', 'city': 'Mouth of Wilson', 'state': 'VA'},
-        {'original': 'Brewster Academy', 'standardized': 'Brewster Academy', 'city': 'Wolfeboro', 'state': 'NH'},
-        {'original': 'Prolific Prep', 'standardized': 'Prolific Prep', 'city': 'Napa', 'state': 'CA'},
-        {'original': 'Spire Academy', 'standardized': 'Spire Institute', 'city': 'Geneva', 'state': 'OH'},
-        {'original': 'Spire Institute', 'standardized': 'Spire Institute', 'city': 'Geneva', 'state': 'OH'},
-        {'original': 'Link Academy', 'standardized': 'Link Academy', 'city': 'Branson', 'state': 'MO'},
-        {'original': 'La Lumiere School', 'standardized': 'La Lumiere School', 'city': 'La Porte', 'state': 'IN'},
-        {'original': 'New Hope Academy', 'standardized': 'New Hope Christian Academy', 'city': 'Landover Hills', 'state': 'MD'},
-        {'original': 'New Hope Christian Academy', 'standardized': 'New Hope Christian Academy', 'city': 'Landover Hills', 'state': 'MD'},
-        {'original': 'Hamilton Heights Christian Academy', 'standardized': 'Hamilton Heights Christian Academy', 'city': 'Chattanooga', 'state': 'TN'},
-        {'original': 'Northfield Mount Hermon', 'standardized': 'Northfield Mount Hermon School', 'city': 'Gill', 'state': 'MA'},
-        {'original': 'Northfield Mount Hermon School', 'standardized': 'Northfield Mount Hermon School', 'city': 'Gill', 'state': 'MA'},
-        {'original': 'South Kent School', 'standardized': 'South Kent School', 'city': 'South Kent', 'state': 'CT'},
-        {'original': 'Wilbraham & Monson Academy', 'standardized': 'Wilbraham & Monson Academy', 'city': 'Wilbraham', 'state': 'MA'},
-        {'original': 'Westtown School', 'standardized': 'Westtown School', 'city': 'West Chester', 'state': 'PA'},
-        {'original': 'Worcester Academy', 'standardized': 'Worcester Academy', 'city': 'Worcester', 'state': 'MA'},
-        {'original': 'The Governor\'s Academy', 'standardized': 'The Governor\'s Academy', 'city': 'Byfield', 'state': 'MA'},
-        {'original': 'Governors Academy', 'standardized': 'The Governor\'s Academy', 'city': 'Byfield', 'state': 'MA'},
-        {'original': 'Blair Academy', 'standardized': 'Blair Academy', 'city': 'Blairstown', 'state': 'NJ'},
-        {'original': 'Putnam Science Academy', 'standardized': 'Putnam Science Academy', 'city': 'Putnam', 'state': 'CT'},
-        {'original': 'St. Andrew\'s School', 'standardized': 'St. Andrew\'s School', 'city': 'Barrington', 'state': 'RI'},
-        {'original': 'Tabor Academy', 'standardized': 'Tabor Academy', 'city': 'Marion', 'state': 'MA'},
-        {'original': 'Choate Rosemary Hall', 'standardized': 'Choate Rosemary Hall', 'city': 'Wallingford', 'state': 'CT'},
-    ]
-
-    mapping_records = []
-    for school in prep_schools:
-        mapping_records.append({
-            'high_school_original': school['original'],
-            'high_school_standardized': school['standardized'],
-            'state': school['state'],
-            'confidence': 'high_manual',
-            'source': 'prep_school_curated',
-            'nces_id': None,
-            'city': school.get('city', ''),
-            'notes': 'Manually curated prep/basketball academy'
-        })
-
-    df = pd.DataFrame(mapping_records)
-    print(f"Created {len(df)} manual prep school mappings")
-
-    return df
 
 
 def analyze_mapping_coverage(mapping_df, unique_schools_file):
@@ -192,11 +63,27 @@ def main():
         print("Run normalize_high_schools.py first")
         return
 
-    # Create duplicate mapping
-    duplicate_mapping = create_duplicate_mapping(duplicates_file)
+    print("Creating duplicate mapping...")
+    duplicates_df = pd.read_csv(duplicates_file)
+
+    # Create duplicate mapping using utilities function
+    duplicate_mapping = create_duplicate_mapping(duplicates_df, group_by_state=True)
+
+    # Add extra columns for compatibility with existing workflow
+    if 'nces_id' not in duplicate_mapping.columns:
+        duplicate_mapping['nces_id'] = None
+
+    print(f"Created {len(duplicate_mapping)} mappings from duplicate resolution")
+    print(f"Reduced to {duplicate_mapping['high_school_standardized'].nunique()} canonical names")
 
     # Create prep school mapping
+    print("\nCreating prep school manual mapping...")
     prep_mapping = create_prep_school_mapping()
+    print(f"Created {len(prep_mapping)} manual prep school mappings")
+
+    # Add extra columns for compatibility with existing workflow
+    if 'nces_id' not in prep_mapping.columns:
+        prep_mapping['nces_id'] = None
 
     # Combine mappings
     all_mappings = pd.concat([duplicate_mapping, prep_mapping], ignore_index=True)


### PR DESCRIPTION
Replace duplicate high school standardization functions with imports
from the hs_standardization package in the utilities repository.

Changes:
- scripts/normalize_high_schools.py: Remove normalize_hs_name,
  extract_disambiguator, categorize_school_type, and
  is_likely_common_name functions; import from hs_standardization
- scripts/build_hs_mapping.py: Remove select_canonical_name,
  create_duplicate_mapping, and create_prep_school_mapping functions;
  import from hs_standardization and update main() to use new API

The standardizing functions are now maintained in a single location
(Sports-Roster-Data/utilities) and can be reused across projects.